### PR TITLE
Fixes npm install permission error

### DIFF
--- a/init/50_devel.sh
+++ b/init/50_devel.sh
@@ -27,7 +27,7 @@ if [[ "$(type -P npm)" ]]; then
   list="$(to_install "${npm_globals[*]}" "${installed[*]}")"
   if [[ "$list" ]]; then
     e_header "Installing Npm modules: $list"
-    npm install -g $list
+    sudo npm install -g $list
   fi
 fi
 


### PR DESCRIPTION
If there are existing node modules in /usr/lib/node_modules/ which are owned by another user (root, for instance) then `npm install` will fail to overwrite them. Prefixing npm install with `sudo` fixes this issue.
