### PR TITLE
Fixes npm update permissions error

### DIFF
--- a/init/50_devel.sh
+++ b/init/50_devel.sh
@@ -21,7 +21,7 @@ source ~/.dotfiles/source/50_devel.sh
 # Install Npm modules.
 if [[ "$(type -P npm)" ]]; then
   e_header "Updating Npm"
-  npm update -g npm
+  sudo npm update -g npm
 
   { pushd "$(npm config get prefix)/lib/node_modules"; installed=(*); popd; } > /dev/null
   list="$(to_install "${npm_globals[*]}" "${installed[*]}")"


### PR DESCRIPTION
Fixes this error when running npm update when /usr/bin/npm and related files in /usr/ are owned by a different user: 

"npm ERR! error rolling back Error: EACCES, unlink '/usr/bin/npm'"
