### PR TITLE
Move ~/.gitconfig from copy/ to link/ . Use include for user.name

### DIFF
--- a/copy/.gitconfig.local
+++ b/copy/.gitconfig.local
@@ -1,0 +1,3 @@
+[user]
+  name = Ben Alman
+  email = EMAIL

--- a/link/.gitconfig
+++ b/link/.gitconfig
@@ -1,6 +1,5 @@
-[user]
-  name = Ben Alman
-  email = EMAIL
+[include]
+  path = .gitconfig.local
 [core]
   autocrlf = input
   whitespace = fix,space-before-tab,tab-in-indent,trailing-space


### PR DESCRIPTION
- Move `user.name` and `user.email` to `~/.gitconfig.local`
- `[include]` the file `~/.gitconfig.local` from `~/.gitconfig`
- Move `~/.gitconfig` from `copy` to `link`

As of git 1.7.10+, it's possible to specify the following syntax in `~/.gitconfig`:

```
[include]
     path = /path/to/file
```

The benefit of having `.gitconfig` in `link/` instead of `copy/` is that updates to git aliases can be kept up to date by just running git pull on the dotfiles repo.
