### PR TITLE
gpr fixes

### DIFF
--- a/bin/gpr
+++ b/bin/gpr
@@ -164,9 +164,9 @@ if [[ $? != 0 || ! "$json" ]]; then
 fi
 
 # Let's parse some JSON.
-remote_url="$(node -pe "($json).head.repo.git_url")"
+remote_url="$(node -pe "($json).head.repo.clone_url")"
 remote_ref="$(node -pe "($json).head.ref")"
-local_url="$(node -pe "($json).base.repo.git_url")"
+local_url="$(node -pe "($json).base.repo.clone_url")"
 local_ref="$(node -pe "($json).base.ref")"
 num_commits="$(node -pe "($json).commits")"
 


### PR DESCRIPTION
Two things, both good.
1. Allow repo urls without .git suffix like `https://github.com/cowboy/dotfiles`
   - Many people just clone the same URL that's in the url bar these days. Let's allow it in the regex.
2. You can't clone `git://` urls anymore.. so we'll use the `clone_url` from the json.

:heart_decoration: 
