### PR TITLE
optionally matches old git status output.

### DIFF
--- a/source/50_prompt.sh
+++ b/source/50_prompt.sh
@@ -58,9 +58,9 @@ function prompt_git() {
   [[ "$output" ]] || output="$(git branch | perl -ne '/^\* \(detached from (.*)\)$/ ? print "($1)" : /^\* (.*)/ && print $1')"
   flags="$(
     echo "$status" | awk 'BEGIN {r=""} \
-      /^# Changes to be committed:$/        {r=r "+"}\
-      /^# Changes not staged for commit:$/  {r=r "!"}\
-      /^# Untracked files:$/                {r=r "?"}\
+        /^(# )?Changes to be committed:$/        {r=r "+"}\
+        /^(# )?Changes not staged for commit:$/  {r=r "!"}\
+        /^(# )?Untracked files:$/                {r=r "?"}\
       END {print r}'
   )"
   if [[ "$flags" ]]; then


### PR DESCRIPTION
This allows both old and new versions to update the prompt properly. Tested with git versions as new as v2.1.0 and as old as v1.8.3.2 (does not go back as far as v1.7.2.5). fixes #28
