### PR TITLE
Allow dotfiles to run from any directory

### DIFF
--- a/bin/dotfiles
+++ b/bin/dotfiles
@@ -21,7 +21,8 @@ exit; fi
 ###########################################
 
 # Where the magic happens.
-export DOTFILES=~/.dotfiles
+[[ -n "$DOTFILES" ]] || export DOTFILES="$(readlink -f "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/..")"
+[[ -n "$DOTFILES" ]] || export DOTFILES="~/.dotfiles"
 
 # Logging stuff.
 function e_header()   { echo -e "\n\033[1m$@\033[0m"; }

--- a/link/.bashrc
+++ b/link/.bashrc
@@ -1,5 +1,6 @@
 # Where the magic happens.
-export DOTFILES=~/.dotfiles
+[[ -n "$DOTFILES" ]] || export DOTFILES="$(readlink -f "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/..")"
+[[ -n "$DOTFILES" ]] || export DOTFILES="~/.dotfiles"
 
 # Add binaries into the path
 PATH=$DOTFILES/bin:$PATH


### PR DESCRIPTION
This allows users use a different name than `.dotfiles`, or to allow a user to have multiple dotfiles.