### PR TITLE
Make echo conditional on terminal stdout

### DIFF
--- a/bin/$
+++ b/bin/$
@@ -5,5 +5,8 @@
 
 # Begone, silly errors! Lazy copy + paste forever!! ETCETERA!!!!
 
-echo 'Quit pasting in commands from the internet, you lazy bum.'
+# Only echo if stdout is a terminal (and not a pipe)
+if [ -t 1 ]; then
+  echo 'Quit pasting in commands from the internet, you lazy bum.'
+fi
 "$@"


### PR DESCRIPTION
For example, copy/pasting a `curl | sh` would cause the echo
message to be piped into the shell and interpreted as a script (which throws
a syntax error).

For example,

```
$ curl -sf -L https://static.rust-lang.org/rustup.sh | sh
sh: line 1: Quit: command not found
```
