### PR TITLE
Fix server

### DIFF
--- a/bin/serve
+++ b/bin/serve
@@ -1,10 +1,10 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import sys, os
-import SimpleHTTPServer
+import http.server
 args = sys.argv[1:]
 
 if len(args) and (args[0] == "-h" or args[0] == "--help"):
-  print """
+  print("""
 Serve a file (or the current directory)
 http://benalman.com/
 
@@ -16,7 +16,7 @@ directory) with the default web browser.
 
 Copyright (c) 2012 "Cowboy" Ben Alman
 Licensed under the MIT license.
-http://benalman.com/about/license/""" % os.path.basename(sys.argv[0])
+http://benalman.com/about/license/""" % os.path.basename(sys.argv[0]))
   sys.exit()
 
 # Get port, if specified.
@@ -35,18 +35,16 @@ if not "SSH_TTY" in os.environ:
 # Redefining the default content-type to text/plain instead of the default
 # application/octet-stream allows "unknown" files to be viewable in-browser
 # as text instead of being downloaded, which makes me happy.
-extensions_map = SimpleHTTPServer.SimpleHTTPRequestHandler.extensions_map
+extensions_map = http.server.SimpleHTTPRequestHandler.extensions_map
 # Set the default content type to text/plain.
 extensions_map[""] = "text/plain"
 # Serving everything as UTF-8 by default makes funky characters render
 # correctly and shouldn't break anything (per Mathias Bynens).
-for key, value in extensions_map.items():
+for key, value in list(extensions_map.items()):
   extensions_map[key] = value + "; charset=UTF-8"
 
 # Start the server using the default .test method, because I'm lazy (the port
 # is still grabbed from sys.argv[1]).
 sys.argv = [sys.argv[0], port]
-try:
-    SimpleHTTPServer.test()
-except KeyboardInterrupt:
-    sys.exit(0)
+print('Starting server. To exit, you may have to press ^C twice.')
+http.server.test(HandlerClass=http.server.SimpleHTTPRequestHandler, port=port, bind='127.0.0.1', protocol='HTTP/1.1')

--- a/bin/serve
+++ b/bin/serve
@@ -46,4 +46,7 @@ for key, value in extensions_map.items():
 # Start the server using the default .test method, because I'm lazy (the port
 # is still grabbed from sys.argv[1]).
 sys.argv = [sys.argv[0], port]
-SimpleHTTPServer.test()
+try:
+    SimpleHTTPServer.test()
+except KeyboardInterrupt:
+    sys.exit(0)

--- a/bin/ssid
+++ b/bin/ssid
@@ -12,10 +12,16 @@ otherwise echo nothing.
 Copyright (c) 2012 "Cowboy" Ben Alman
 Licensed under the MIT license.
 http://benalman.com/about/license/
+
+Altered by Scott Severance to work on Ubuntu, as well.
 HELP
 exit; fi
 
-ssid=$(/System/Library/PrivateFrameworks/Apple80211.framework/Versions/A/Resources/airport -I | sed -En 's/^ +SSID: +//p')
+if [[ -f '/System/Library/PrivateFrameworks/Apple80211.framework/Versions/A/Resources/airport' ]]; then
+    ssid="$(/System/Library/PrivateFrameworks/Apple80211.framework/Versions/A/Resources/airport -I | sed -En 's/^ +SSID: +//p')"
+elif [[ iwconfig >/dev/null ]]; then
+    ssid="$(iwconfig 2>/dev/null | grep SSID | cut -d\" -f2)"
+fi
 
 if [ "$1" ]; then
   if [ "$(echo $ssid | grep -w $1)" ]; then


### PR DESCRIPTION
bin/serve can be difficult to exit, requiring me to look up its pid and manually kill it. I converted it to Python 3, which enables me to kill it more normally by issuing ^C as expected. The only thing is, I still have to hit ^C twice sometimes, so there's now a note explaining that. It's better than before, but far from perfect.

Note: I messed up my branch history, so the only file that is really a part of this merge request is bin/serve. Unfortunately, I can't figure out how to remove bin/ssid from this pull request.