### PR TITLE
move macvim to recipes and add options to override sytem vim

### DIFF
--- a/init/30_osx_homebrew_casks.sh
+++ b/init/30_osx_homebrew_casks.sh
@@ -35,7 +35,6 @@ casks=(
   iterm2
   karabiner-elements
   launchbar
-  macvim
   messenger-for-desktop
   midi-monitor
   moom

--- a/init/30_osx_homebrew_recipes.sh
+++ b/init/30_osx_homebrew_recipes.sh
@@ -19,6 +19,7 @@ recipes=(
   id3tool
   jq
   lesspipe
+  macvim --HEAD --with-lua --with-luajit --with-override-system-vim
   man2html
   mercurial
   nmap


### PR DESCRIPTION
macvim isn't in cask, options override the default system vim and others are needed with macos